### PR TITLE
Fix Sentry env export

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,3 +1,3 @@
 use nix
 
-VITE_SENTRY_DSN=some_dsn
+export VITE_SENTRY_DSN=some_dsn

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,8 +16,11 @@ const app = Elm.Main.init({
   flags: null,
 });
 
+const isProd = (): boolean => import.meta.env.PROD ?? false;
+
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN ?? "",
+  debug: !isProd(),
   integrations: [new BrowserTracing()],
 
   // Set tracesSampleRate to 1.0 to capture 100%
@@ -25,8 +28,6 @@ Sentry.init({
   // We recommend adjusting this value in production
   tracesSampleRate: 1.0,
 });
-
-const isProd = (): boolean => import.meta.env.PROD ?? false;
 
 const css: string = "color: #ffffff; background-color: #4c48ef; padding: 4px;";
 


### PR DESCRIPTION
Wasn't exporting the darn env var so it wasn't picked up in the build process which resulted in an empty string being used as the Sentry DSN.

**Note:** 

Some browsers will block loggers (like Sentry) e.g. Brave